### PR TITLE
ci: Prepare actionlint workflow for GitHub App token

### DIFF
--- a/.github/workflows/update-actionlint-workflow.yml
+++ b/.github/workflows/update-actionlint-workflow.yml
@@ -113,13 +113,13 @@ jobs:
 
             # Replace 'Homebrew' with 'PikachuEXE' in .github/workflows/actionlint.yml
             file=".github/workflows/actionlint.yml"
-  
+
             # Check the current state of the condition before attempting a substitution
             expected_condition="github.repository_owner == 'Homebrew'"
             current_upstream_condition="$(yq eval '.jobs.workflow_syntax.if' "$file")"
             # Isolate the repository owner name:
             # yq eval '.jobs.workflow_syntax.if' "$file" | sed -n "s/.*github.repository_owner == '\(.*\)'.*/\1/p"
-  
+
             # Warn and overwrite if condition is unexpected
             if [ "$current_upstream_condition" != "$expected_condition" ]; then
               # Use GitHub Actions annotation
@@ -127,7 +127,7 @@ jobs:
               echo "::warning file=${file},line=${line}::Unexpected 'workflow_syntax' condition in downloaded workflow"
               echo "Upstream: $current_upstream_condition"
               echo "Expected: $expected_condition"
-  
+
               # Replace entire condition
               if ! yq eval ".jobs.workflow_syntax.if = \"github.repository_owner == '${{ env.repository_owner }}'\"" "$file" --inplace --exit-status; then
                 echo "ERROR: An error occurred during the yq operation in 'workflow_syntax' step."
@@ -140,7 +140,7 @@ jobs:
                 exit 1  # Exit with an error code to fail the workflow
               fi
             fi
-  
+
             echo "Repository Owner Check substitution successful."
           fi
 
@@ -148,7 +148,7 @@ jobs:
         run: |
           if [ "${gh_actionlint_yaml_downloaded}" = "true" ]; then
             echo "Configuring actionlint to disallow GitHub configuration variables in workflow files."
-  
+
             # Reset 'config-variables' to an empty array in .github/actionlint.yaml
             # This excludes Homebrew/brew’s configuration variables, prevents additional ones,
             # and aligns with the empty 'config-variables' array in Homebrew/homebrew-core and Homebrew/actions.
@@ -156,23 +156,23 @@ jobs:
               echo "ERROR: An error occurred during the yq operation in 'Reset config-variables' step."
               exit 1  # Exit with an error code to fail the workflow
             fi
-  
+
             echo "'config-variables' reset successful."
           fi
 
-      - name: Check for Workflow Changes
-        run: |
-          # Check if there are any changes in the workflow files
-          if git diff --quiet; then
-            echo "No changes in workflows. Exiting."
-            exit 0
-          fi
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          revoke_token: true
 
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: "${{ steps.get_workflow_token.outputs.token }}"
           commit-message: '[create-pull-request] Update actionlint workflow'
           delete-branch: true
           title: 'Update actionlint workflow'


### PR DESCRIPTION
This uses [peter-murray/workflow-application-token-action](https://github.com/peter-murray/workflow-application-token-action "https://github.com/peter-murray/workflow-application-token-action") to get the token from your GitHub App, once you set that up. Please see the link for details how to set it up. In short, you create and own the GitHub App, install it in this repo, and add secrets to this repo for the app's ID and private key.

**Important:** This assumes you name your secrets `APPLICATION_ID` and `APPLICATION_PRIVATE_KEY`. If you use different names, update the workflow file accordingly.

---

As I understand it:

#### Permissions

It seems the GitHub App would need these Repository permissions:

`Contents` `Access: Read & write`
`Pull requests` `Access: Read & write`
`Workflows` `Access: Read & write`
`Metadata` `Access: Read only` (automatically selected when selecting the contents permission)

#### Creating and registering the GitHub App

1. GitHub App Name: Choose a name, such as "Token Generator."

1. Description: Something like "GitHub App to generate short-lived tokens for workflows."

1. Homepage URL: You can use a placeholder URL or provide a link to relevant docs or info, such as "https://github.com/PikachuEXE/homebrew-FreeTube"

1. Webhook Active: Inactive. This setting determines whether the GitHub App will receive events via webhooks, which you do not need to handle.

1. Scope of "Where can this GitHub App be installed?": Only this repository.

1. The "Identifying and authorizing users" section in the app creation settings is not directly relevant.

1. When storing a private key as a secret in GitHub, it's generally recommended to encode the private key in base64 format before storing it (GNU coreutils will line-wrap long tokens, so delete any newlines): `cat private-key.pem | base64 | tr -d "\n"`. Create a new secret in the repo, and use the base64-encoded private key as the value for the secret. GitHub will automatically decode the base64-encoded value and provide it as the original private key to the calling workflow.

---

While there, clean up extra spaces and remove useless step. `git diff` doesn't work on untracked files and the subsequent peter-evans/create-pull-request step does properly handle untracked files.