### PR TITLE
actions/build-release

### DIFF
--- a/.github/release-notes-template.md
+++ b/.github/release-notes-template.md
@@ -1,0 +1,12 @@
+## Release Notes - %%{release.tag_name}%%
+
+This special release provides native compatibility for Apple Silicon Macs.
+
+It can be conveniently installed using [Homebrew](https://brew.sh/ "https://brew.sh/") through [FreeTube’s Homebrew Tap for Apple Silicon](https://github.com/PikachuEXE/homebrew-FreeTube "https://github.com/PikachuEXE/homebrew-FreeTube"). Check out the [README](https://github.com/PikachuEXE/homebrew-FreeTube "https://github.com/PikachuEXE/homebrew-FreeTube") for our quick installation instructions.
+
+For details about the main FreeTube release, check out its [release notes](%%{release.download_url}%% "%%{release.download_url}%%").
+
+
+#### Important Note
+
+We recommend installing this release using Homebrew for the smoothest experience. However, if you prefer direct downloads, be aware of the Gatekeeper quarantine. Find instructions on removing it [here](https://github.com/PikachuEXE/homebrew-FreeTube/blob/master/README.md#about---no-quarantine "https://github.com/PikachuEXE/homebrew-FreeTube/blob/master/README.md#about---no-quarantine").

--- a/.github/workflows/release-manual-trigger.yml
+++ b/.github/workflows/release-manual-trigger.yml
@@ -1,0 +1,224 @@
+name: Build and Release (Manual Trigger)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name of the upstream release'
+        required: true
+        default: 'v0.19.2-beta'
+      node_version:
+        description: 'Node.js version to use'
+        required: true
+        default: '18.x'
+
+jobs:
+  manual-build:
+    # Use macos-14 for arm64 architecture: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+    # macos-latest refers to the macos-12 (x86_64) runner image until April–June 2024: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ and https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: macos-14
+    outputs:
+      extracted-package-version: "${{ steps.extract-version.outputs.package_version }}"
+
+    steps:
+      - name: Checkout FreeTube Repository at the Provided Release Tag
+        uses: actions/checkout@v4
+        with:
+          repository: FreeTubeApp/FreeTube
+          ref: "${{ github.event.inputs.tag_name }}"
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ github.event.inputs.node_version }}"
+          # Cache the global `yarn cache dir` for faster builds by reusing dependencies.
+          # NOTE: Avoid caching the project-specific node_modules directory to prevent dependency conflicts and ensure proper cache updates. As the documentation to actions/cache states: "it can break across Node versions and won't work with npm ci."
+          cache: "yarn"
+
+      - name: Install Dependencies
+        # Use --frozen-lockfile for reproducible CI builds.
+        # NOTE: ---frozen-lockfile was renamed to --immutable in yarn 2.0.0.
+        # As of 2024-01-30, the macos-14 runner has yarn 1.22.19 installed.
+        # Upstream defines `yarn ci` as `yarn install --silent --frozen-lockfile` in package.json (see output of `jq '.scripts.ci' package.json`).
+        run: yarn ci
+
+      - name: Configure FreeTube Build
+        run: |
+          # Configure Electron Builder to build only the DMG target on macOS
+          sed -i '' "s/targets = Platform.MAC.createTarget(\[[^]]*\], arch)/targets = Platform.MAC.createTarget(\['DMG'\], arch)/" _scripts/build.js
+
+          # Configure Electron Builder artifactName to match the format used by upstream for artifact uploads
+          # NOTE: The ${arch} macro expands to arm64 on Apple Silicon, but this might not be documented yet.
+          # Verify the source code for accurate information:
+          # https://github.com/electron-userland/electron-builder/blob/master/packages/builder-util/src/arch.ts#L35-L51
+          jq '.build.artifactName = "${name}-${version}-${os}-${arch}.${ext}"' package.json > temp.json
+          mv -f temp.json package.json
+
+      - name: Build FreeTube
+        run: |
+          # Build the application and create Disk iMaGe (DMG)
+          yarn build:arm64
+          # Clean up build artifacts: remove .app directory
+          rm -rf build/mac-arm64
+
+      - name: Extract Package Version Number
+        id: extract-version
+        run: |
+          package_version="$(yq '.version' build/latest-mac.yml)"
+          echo "Package Version Number: $package_version"
+
+          # Export variable for later steps and jobs
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload DMG Artifact
+        env:
+          PACKAGE_VERSION: "{{ steps.extract-version.outputs.package_version }}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: FreeTube-DMG
+          path: "build/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg"
+          # Minimum artifact retention is 1 day
+          retention-days: 1
+          # Skip compression for faster upload of pre-compressed binary (DMG) file
+          compression-level: 0
+
+  get-release-info:
+    runs-on: ubuntu-latest
+    outputs:
+      html_url: "${{ steps.extract-info.outputs.html_url }}"
+      name: "${{ steps.extract-info.outputs.name }}"
+      prerelease: "${{ steps.extract-info.outputs.prerelease }}"
+
+    steps:
+      - name: Extract Release Information
+        id: extract-info
+        run: |
+          echo "Fetching release information for release ${tag_name}..."
+
+          owner="FreeTubeApp"
+          repo="FreeTube"
+          tag_name="${{ github.event.inputs.tag_name }}"
+
+          # Send a GET request to the GitHub API to fetch the releases
+          response=$(
+            curl --fail --silent --show-error --location \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              --url "https://api.github.com/repos/${owner}/${repo}/releases"
+          )
+
+          # Check if response is empty
+          if [ -z "$response" ]; then
+            echo "Error: Failed to fetch release information."
+            exit 1
+          fi
+
+          # Iterate through each release
+          release_found=false
+          for row in $(echo "${response}" | jq -r '.[] | @base64'); do
+              _jq() {
+               echo "${row}" | base64 --decode | jq --raw-output "${1}"
+              }
+
+              # Check if the release’s tag_name matches the desired one
+              # shellcheck disable=SC2129
+              if [ "$(_jq '.tag_name')" == "$tag_name" ]; then
+                  # Extract and print the html_url
+                  html_url="$(_jq '.html_url')"
+                  # Extract and print the name
+                  name="$(_jq '.name')"
+                  # Extract and print the pre-release status
+                  prerelease="$(_jq '.prerelease')"
+
+                  echo "html_url=${html_url}" >> "$GITHUB_OUTPUT"
+                  echo "name=${name}" >> "$GITHUB_OUTPUT"
+                  echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+
+                  echo "Release ${tag_name}:"
+                  echo "  HTML URL:      ${html_url}"
+                  echo "  Name:          ${name}"
+                  echo "  Pre-release:   ${prerelease}"
+
+                  release_found=true
+                  break
+              fi
+          done
+
+          # Check if the desired release was found
+          if [ "$release_found" = false ]; then
+            echo "Error: Release ${tag_name} not found."
+            exit 1
+          fi
+
+          echo "Fetching release information completed successfully."
+
+  manual-release:
+    needs:
+      - manual-build
+      - get-release-info
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: "${{ needs.manual-build.outputs.extracted-package-version }}"
+
+    steps:
+      - name: Download Built DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: FreeTube-DMG
+          # Document use of default destination path
+          path: ${{ github.workspace }}
+
+      # Checkout Release Notes Template
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          # Use cone mode for sparse-checkout, as non-cone mode is deprecated in Git.
+          sparse-checkout: .github
+          # sparse-checkout: .github/release-notes-template.md
+          # sparse-checkout-cone-mode: false
+
+      - name: Generate Release Notes
+        run: |
+          # Set default template content
+          default_template="Release ${{ github.event.inputs.tag_name }} for Apple Silicon Homebrew Tap."
+
+          # Check if the release notes template file exists and is readable
+          if [ ! -r ".github/release-notes-template.md" ]; then
+            echo "Warning: Release notes template not readable. Using simplified default."
+            echo "$default_template" > "${{ github.workspace }}/release_notes.md"
+            echo "Release notes generated and saved to: ${{ github.workspace }}/release_notes.md"
+          else
+            # Generate release notes using the template file
+            sed \
+              -e "s/%%{release.tag_name}%%/${{ github.event.inputs.tag_name }}/g" \
+              -e "s/%%{release.download_url}%%/${{ needs.get-release-info.outputs.html_url }}/g" \
+              .github/release-notes-template.md \
+              > "${{ github.workspace }}/release_notes.md"
+            echo "Release notes generated and saved to: ${{ github.workspace }}/release_notes.md"
+          fi
+
+      - name: Create Release and Upload Artifact
+        id: gh-release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            "${{ github.workspace }}/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg"
+          fail_on_unmatched_files: true
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: "${{ github.event.inputs.tag_name }}"
+          name: "${{ needs.get-release-info.outputs.name }}"
+          # body: "Release for Apple Silicon Homebrew Tap."
+          body_path: "${{ github.workspace }}/release_notes.md"
+          # The information in the inputs context and github.event.inputs context is identical except that the inputs context preserves Boolean values as Booleans instead of converting them to strings.
+          prerelease: "${{ needs.get-release-info.outputs.prerelease }}"
+
+      - name: Print Release Information
+        run: |
+          echo "FreeTube built and released to Homebrew Tap for Apple Silicon:"
+          echo "  Release ID: ${{ steps.gh-release.outputs.id }}"
+          echo "  Release URL: ${{ steps.gh-release.outputs.url }}"
+          echo "  Download URL: ${{ fromJSON(steps.gh-release.outputs.assets)[0].browser_download_url }}"
+
+      - name: Completion Message
+        run: echo "Workflow 'Build and Release' completed successfully!"

--- a/.github/workflows/release-upstream-trigger.yml
+++ b/.github/workflows/release-upstream-trigger.yml
@@ -1,0 +1,163 @@
+name: Build and Release (Upstream Trigger)
+
+on:
+  # NOTE: Repository dispatch events will only trigger a workflow run if the workflow is committed to the target’s default branch. (In other words, make sure this file is on the master branch of the Homebrew Tap.)
+  repository_dispatch:
+    types:
+      - upstream-release
+
+jobs:
+  display-received-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Display Event Information
+          # The ${{ github.event.action }} expression typically expands to the custom event type that triggered the workflow, i.e., 'upstream-release'.
+        run: echo "Received event '${{ github.event.action }}' from '${{ github.event.client_payload.release.repository }}'"
+
+      - name: Display Information from Dispatching Repository
+        run: |
+          echo "Dispatching repository provided the following information:"
+          echo "  Node version: ${{ github.event.client_payload.node.version }}"
+          echo "  Release ID: ${{ github.event.client_payload.release.id }}"
+          echo "  Release Tag Name: ${{ github.event.client_payload.release.tag_name }}"
+          echo "  Release Name: ${{ github.event.client_payload.release.name }}"
+          echo "  Release URL: ${{ github.event.client_payload.release.html_url }}"
+          echo "  Pre-release: ${{ github.event.client_payload.release.prerelease }}"
+
+  upstream-build:
+    # Use macos-14 for arm64 architecture: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
+    # macos-latest refers to the macos-12 (x86_64) runner image until April–June 2024: https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/ and https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+    runs-on: macos-14
+    outputs:
+      extracted-package-version: "${{ steps.extract-version.outputs.package_version }}"
+
+    steps:
+      - name: Checkout FreeTube Repository at the Provided Release Tag
+        uses: actions/checkout@v4
+        with:
+          repository: FreeTubeApp/FreeTube
+          ref: "${{ github.event.client_payload.release.tag_name }}"
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "${{ github.event.client_payload.node.version }}"
+          # Cache the global `yarn cache dir` for faster builds by reusing dependencies.
+          # NOTE: Avoid caching the project-specific node_modules directory to prevent dependency conflicts and ensure proper cache updates. As the documentation to actions/cache states: "it can break across Node versions and won't work with npm ci."
+          cache: "yarn"
+
+      - name: Install Dependencies
+        # Use --frozen-lockfile for reproducible CI builds.
+        # NOTE: ---frozen-lockfile was renamed to --immutable in yarn 2.0.0.
+        # As of 2024-01-30, the macos-14 runner has yarn 1.22.19 installed.
+        # Upstream defines `yarn ci` as `yarn install --silent --frozen-lockfile` in package.json (see output of `jq '.scripts.ci' package.json`).
+        run: yarn ci
+
+      - name: Configure FreeTube Build
+        run: |
+          # Configure Electron Builder to build only the DMG target on macOS
+          sed -i '' "s/targets = Platform.MAC.createTarget(\[[^]]*\], arch)/targets = Platform.MAC.createTarget(\['DMG'\], arch)/" _scripts/build.js
+
+          # Configure Electron Builder artifactName to match the format used by upstream for artifact uploads
+          # NOTE: The ${arch} macro expands to arm64 on Apple Silicon, but this might not be documented yet.
+          # Verify the source code for accurate information:
+          # https://github.com/electron-userland/electron-builder/blob/master/packages/builder-util/src/arch.ts#L35-L51
+          jq '.build.artifactName = "${name}-${version}-${os}-${arch}.${ext}"' package.json > temp.json
+          mv -f temp.json package.json
+
+      - name: Build FreeTube
+        run: |
+          # Build the application and create Disk iMaGe (DMG)
+          yarn build:arm64
+          # Clean up build artifacts: remove .app directory
+          rm -rf build/mac-arm64
+
+      - name: Extract Package Version Number
+        id: extract-version
+        run: |
+          package_version="$(yq '.version' build/latest-mac.yml)"
+          echo "Package Version Number: $package_version"
+
+          # Export variable for later steps and jobs
+          echo "package_version=$package_version" >> "$GITHUB_OUTPUT"
+
+      - name: Upload DMG Artifact
+        env:
+          PACKAGE_VERSION: "{{ steps.extract-version.outputs.package_version }}"
+        uses: actions/upload-artifact@v4
+        with:
+          name: FreeTube-DMG
+          path: "build/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg"
+          # Minimum artifact retention is 1 day
+          retention-days: 1
+          # Skip compression for faster upload of pre-compressed binary (DMG) file
+          compression-level: 0
+
+  upstream-release:
+    needs:
+      - upstream-build
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_VERSION: "${{ needs.upstream-build.outputs.extracted-package-version }}"
+
+    steps:
+      - name: Download Built DMG
+        uses: actions/download-artifact@v4
+        with:
+          name: FreeTube-DMG
+          # Document use of default destination path
+          path: ${{ github.workspace }}
+
+      # Checkout Release Notes Template
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          # Use cone mode for sparse-checkout, as non-cone mode is deprecated in Git.
+          sparse-checkout: .github
+          # sparse-checkout: .github/release-notes-template.md
+          # sparse-checkout-cone-mode: false
+
+      - name: Generate Release Notes
+        run: |
+          # Set default template content
+          default_template="Release ${{ github.event.client_payload.release.tag_name }} for Apple Silicon Homebrew Tap."
+
+          # Check if the release notes template file exists and is readable
+          if [ ! -r ".github/release-notes-template.md" ]; then
+            echo "Warning: Release notes template not readable. Using simplified default."
+            echo "$default_template" > "${{ github.workspace }}/release_notes.md"
+            echo "Release notes generated and saved to: ${{ github.workspace }}/release_notes.md"
+          else
+            # Generate release notes using the template file
+            sed \
+              -e "s/%%{release.tag_name}%%/${{ github.event.client_payload.release.tag_name }}/g" \
+              -e "s/%%{release.download_url}%%/${{ github.event.client_payload.release.download_url }}/g" \
+              .github/release-notes-template.md \
+              > "${{ github.workspace }}/release_notes.md"
+            echo "Release notes generated and saved to: ${{ github.workspace }}/release_notes.md"
+          fi
+
+      - name: Create Release and Upload Artifact
+        id: gh-release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            "${{ github.workspace }}/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg"
+          fail_on_unmatched_files: true
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          tag_name: "${{ github.event.client_payload.release.tag_name }}"
+          name: "${{ github.event.client_payload.release.name }}"
+          # body: "Release for Apple Silicon Homebrew Tap."
+          body_path: "${{ github.workspace }}/release_notes.md"
+          prerelease: "${{ github.event.client_payload.release.prerelease }}"
+
+      - name: Print Release Information
+        run: |
+          echo "FreeTube built and released to Homebrew Tap for Apple Silicon:"
+          echo "  Release ID: ${{ steps.gh-release.outputs.id }}"
+          echo "  Release URL: ${{ steps.gh-release.outputs.url }}"
+          echo "  Download URL: ${{ fromJSON(steps.gh-release.outputs.assets)[0].browser_download_url }}"
+
+      - name: Completion Message
+        run: echo "Workflow 'Build and Release' completed successfully!"

--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -1,0 +1,28 @@
+name: Update Homebrew Tap
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  update-homebrew-cask:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          revoke_token: true
+          permissions: "contents:write, metadata:read, pull_requests:write"
+
+      - name: Update Homebrew Cask
+        uses: eugenesvk/action-homebrew-bump-cask@v3.8.4
+        with:
+          token: "${{ steps.get_workflow_token.outputs.token }}"
+          tap: PikachuEXE/homebrew-FreeTube
+          cask: pikachuexe-freetube

--- a/Casks/pikachuexe-freetube.rb
+++ b/Casks/pikachuexe-freetube.rb
@@ -1,6 +1,6 @@
 cask "pikachuexe-freetube" do
-  version "0.19.1"
-  sha256 "0ff50bd11a372166b7860c7eedfe8757b1411b71b4356ea40849fee8c6b7ccdb"
+  version "0.19.2"
+  sha256 "f369a2e2fbb7a5a1aeec433364268a19ee814adacfa45f6dc0c33813ff763a21"
 
   url "https://github.com/PikachuEXE/homebrew-FreeTube/releases/download/v#{version}-beta/freetube-#{version}-mac-arm64.dmg"
   name "FreeTube"

--- a/script/check-workflow-status.sh
+++ b/script/check-workflow-status.sh
@@ -1,0 +1,72 @@
+#! /bin/bash
+set -o errexit
+set -o nounset
+
+# Script to determine whether the upstream release.yml workflow was run
+# and when it was last run, using the GitHub API.
+
+# Replace placeholders with actual values
+UPSTREAM_REPO="FreeTubeApp/FreeTube"
+WORKFLOW_FILE="release.yml"
+WORKFLOW_PATH=".github/workflows/$WORKFLOW_FILE"
+# GITHUB_TOKEN="your_personal_access_token"
+
+# Step 1: Get Workflow ID
+WORKFLOW_ID=$(curl --silent \
+  "https://api.github.com/repos/$UPSTREAM_REPO/actions/workflows" | \
+  jq -r ".workflows[] | select(.path == \"$WORKFLOW_PATH\") | .id")
+
+# Step 2: List Workflow Runs
+LATEST_RUN=$(curl --silent \
+  "https://api.github.com/repos/$UPSTREAM_REPO/actions/workflows/$WORKFLOW_ID/runs" | \
+  jq -r ".workflow_runs[0]")
+
+# Step 3: Extract Run Status and Timestamp
+STATUS=$(jq -r ".status" <<< "$LATEST_RUN")
+# The timestamp is in ISO 8601 format
+TIMESTAMP_UTC=$(jq -r ".created_at" <<< "$LATEST_RUN")
+
+# Step 4: Convert Timestamp to Local Timezone
+# Check if Ruby is installed
+if command -v ruby >/dev/null 2>&1; then
+  # Ruby is installed, use it for precise timestamp conversion
+  # Match the default output of the 'date' command
+  TIMESTAMP_LOCAL=$(ruby -r 'time' -e "puts Time.parse('$TIMESTAMP_UTC').localtime.strftime('%a %b %d %H:%M:%S %Z %Y')")
+  # Follow the ISO 8601 standard
+  # TIMESTAMP_LOCAL=$(ruby -r 'time' -e "puts Time.parse('$TIMESTAMP_UTC').localtime.strftime('%Y-%m-%d %H:%M:%S %Z')")
+else
+  # Ruby is not installed
+  # Check the operating system
+  OS=$(uname -s)
+  if [ "$OS" == "Darwin" ]; then
+    # macOS
+    # Use date command for less precise timestamp conversion
+    # This approach might not be as precise as using Ruby, especially if dealing with daylight saving time changes.
+    OFFSET=$(date +%z)
+
+    # Extract the sign (+/-) and hours from the offset
+    HOURS=${OFFSET:0:3}
+
+    # Adjust timestamp using the -v option
+    # Match the default output of the 'date' command
+    TIMESTAMP_LOCAL=$(date -jf "%Y-%m-%dT%H:%M:%SZ" -v"${HOURS}H" "$TIMESTAMP_UTC" +"%a %b %d %H:%M:%S %Z %Y")
+    # Follow the ISO 8601 standard
+    # TIMESTAMP_LOCAL=$(date -jf "%Y-%m-%dT%H:%M:%SZ" -v"${HOURS}H" "$TIMESTAMP_UTC" +"%Y-%m-%d %H:%M:%S %Z")
+  elif [ "$OS" == "Linux" ]; then
+    # Linux
+    # Use date command with --date option from GNU coreutils for precise timestamp conversion
+    # Match the default output of the 'date' command
+    TIMESTAMP_LOCAL=$(date --date="$TIMESTAMP_UTC" +"%a %b %d %H:%M:%S %Z %Y")
+    # Follow the ISO 8601 standard
+    # TIMESTAMP_LOCAL=$(date --date="$TIMESTAMP_UTC" +"%Y-%m-%d %H:%M:%S %Z")
+  else
+    # Unsupported OS, print UTC timestamp without changed formatting
+    TIMESTAMP_LOCAL="$TIMESTAMP_UTC"
+  fi
+fi
+
+# Step 5: Check Run Status and Print the Results
+if [ "$STATUS" == "completed" ]; then
+  printf "The %s workflow was last run successfully at %s.\n" "$WORKFLOW_FILE" "$TIMESTAMP_LOCAL"
+else
+  printf "The %s workflow has not been run or did not complete successfully.\n" "$WORKFLOW_FILE"


### PR DESCRIPTION
Untested.

The first commit implements two workflows: one triggered on receiving an event from upstream to build and release FreeTube and one triggered when this repo publishes its release to update the cask definition.

**Important: This will require additions to the upstream repository in order to work.**
Upstream will have to add your two GitHub App secrets to the FreeTubeApp/FreeTube repo and also commit a new workflow (see below).

The second commit implements one workflow: triggered manually. This requires two inputs to be entered when triggering: the Node.js version to use (currently `18.x`) and the Tag Name of the upstream release (currently `v0.19.2-beta`).

---

The workflow to be committed upstream consists of the following (on my system I called it `notify-tap.yml`):
```yml
name: Notify Downstream Homebrew Tap

on:
  release:
    types:
      - published
env:
  node_version: 18.x
jobs:
  notify:
    runs-on: ubuntu-latest
    steps:
      - name: Get Token from GitHub App
        id: app-token
        uses: peter-murray/workflow-application-token-action@v3
        with:
          application_id: ${{ secrets.APPLICATION_ID }}
          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
          permissions: "contents:write, metadata:read"
          revoke_token: true

      - name: Dispatch to Homebrew Tap Repository
        uses: peter-evans/repository-dispatch@v3
        with:
          token: "${{ steps.app-token.outputs.token }}"
          repository: PikachuEXE/homebrew-FreeTube
          event-type: notify-tap
          # The Client Payload is vital for the dispatched workflow, providing the Node.js version and tag name for the build, and essential details for release publishing--name, tag name, prerelease status, and upstream release URL (for referencing in release notes). Additional keys are used for information reporting or reserved for potential future use or troubleshooting.
          client-payload: |
            {
              "node": {
                "version": "${{ env.node_version }}"
              },
              "release": {
                "html_url": "${{ github.event.release.html_url }}",
                "id": "${{ github.event.release.id }}",
                "name": "${{ github.event.release.name }}",
                "prerelease": "${{ github.event.release.prerelease }}",
                "repository": "${{ github.event.release.repository }}",
                "tag_name": "${{ github.event.release.tag_name }}"
              }
            }

      - name: Completion Message
        run: echo "Dispatch to Homebrew Tap completed successfully!"
```

---

This section is for the upstream pull request:

**Overview:**
This pull request adds the Homebrew Tap integration workflow for streamlined release actions. The integration consists of two workflows—one upstream (here), triggered on published releases, and another downstream (the Homebrew Tap), triggered by a `repository_dispatch` event from upstream.

**Notes for Upstream:**
- Please ensure that your repository incorporates the necessary secrets for the integration to function seamlessly.
- Be aware that the ongoing maintenance burden will involve periodic updates to the Node.js version used in the workflow. Similar to several of your existing workflows (e.g., [build.yml](https://github.com/FreeTubeApp/FreeTube/blob/development/.github/workflows/build.yml), [linter.yml](https://github.com/FreeTubeApp/FreeTube/blob/development/.github/workflows/linter.yml), [release.yml](https://github.com/FreeTubeApp/FreeTube/blob/development/.github/workflows/release.yml)), keeping the Node.js version up-to-date is crucial for maintaining compatibility.