### PR TITLE
fix: use GitHub App token for triggering

### DIFF
--- a/.github/workflows/release-manual-trigger.yml
+++ b/.github/workflows/release-manual-trigger.yml
@@ -201,6 +201,15 @@ jobs:
           # Document use of default destination path
           path: ${{ github.workspace }}
 
+      - name: Get Token
+        id: get_workflow_token
+        uses: peter-murray/workflow-application-token-action@v3
+        with:
+          application_id: ${{ secrets.APPLICATION_ID }}
+          application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          revoke_token: true
+          permissions: "contents:write, metadata:read"
+
       - name: Create Release and Upload Artifact
         id: gh-release
         uses: softprops/action-gh-release@v2
@@ -208,7 +217,7 @@ jobs:
           files: |
             ${{ github.workspace }}/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg
           fail_on_unmatched_files: true
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          token: "${{ steps.get_workflow_token.outputs.token }}"
           tag_name: "${{ github.event.inputs.tag_name }}"
           name: "${{ needs.get-release-info.outputs.name }}"
           # body: "Release for Apple Silicon Homebrew Tap."


### PR DESCRIPTION
This note was added to the docs for the softprops/action-gh-release action two weeks ago, apparently after I had already worked on that part three weeks ago:

> Note that if you intend to run workflows on the release event (on: { release: { types: [published] } }), you need to use a personal access token for this action, as the https://github.com/actions/create-release/issues/71.

Please delete the release and re-run the release-manual-trigger workflow after merging this to see if this fixes the problem.