### PR TITLE
release-manual-trigger.yml: use `brew bump`

### DIFF
--- a/.github/workflows/release-manual-trigger.yml
+++ b/.github/workflows/release-manual-trigger.yml
@@ -232,4 +232,4 @@ jobs:
           echo "  Download URL: ${{ fromJSON(steps.gh-release.outputs.assets)[0].browser_download_url }}"
 
       - name: Completion Message
-        run: echo "Workflow 'Build and Release' completed successfully!"
+        run: echo "Workflow 'Build and Release (Manual Trigger)' completed successfully!"

--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -18,7 +18,7 @@ jobs:
           application_id: ${{ secrets.APPLICATION_ID }}
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
           revoke_token: true
-          permissions: "contents:write, metadata:read, pull_requests:write, workflows:write"
+          permissions: "contents:write, metadata:read, pull_requests:write"
 
       - name: Update Homebrew Cask
         uses: eugenesvk/action-homebrew-bump-cask@3.8.4


### PR DESCRIPTION
This is option 2/2. I think it's the simplest, and I like that it leverages the Homebrew infrastructure. If you're interested, let's see if it works.

**Caveat**: If `brew bump` detects an existing PR to bump a cask, open _or closed,_ it will not open a new one.