### PR TITLE
ci: pin actions to a full length commit SHA

### DIFF
--- a/.github/workflows/release-manual-trigger.yml
+++ b/.github/workflows/release-manual-trigger.yml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout FreeTube Repository at the Provided Release Tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: FreeTubeApp/FreeTube
           ref: "${{ github.event.inputs.tag_name }}"
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "${{ github.event.inputs.node_version }}"
           # Cache the global `yarn cache dir` for faster builds by reusing dependencies.
@@ -73,7 +73,7 @@ jobs:
       - name: Upload DMG Artifact
         env:
           PACKAGE_VERSION: "${{ steps.extract-version.outputs.package_version }}"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: FreeTube-DMG
           path: "build/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg"
@@ -167,7 +167,7 @@ jobs:
     steps:
       # Checkout Release Notes Template
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Using cone mode (the default) for sparse-checkout, as non-cone mode is deprecated in Git.
           sparse-checkout: .github
@@ -195,7 +195,7 @@ jobs:
           fi
 
       - name: Download Built DMG
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: FreeTube-DMG
           # Document use of default destination path
@@ -203,7 +203,7 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v4
+        uses: peter-murray/workflow-application-token-action@8e4e6fbf6fcc8a272781d97597969d21b3812974 # v4.0.0
         with:
           application_id: ${{ secrets.APPLICATION_ID }}
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
@@ -212,7 +212,7 @@ jobs:
 
       - name: Create Release and Upload Artifact
         id: gh-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
           files: |
             ${{ github.workspace }}/freetube-${{ env.PACKAGE_VERSION }}-mac-arm64.dmg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/update-tap.yml
+++ b/.github/workflows/update-tap.yml
@@ -31,7 +31,7 @@ jobs:
           out-file-path: "downloads"
 
       - name: Generate Checksums
-        uses: jmgilman/actions-generate-checksum@v1.0.1
+        uses: jmgilman/actions-generate-checksum@3ea6dc9bf8eecf28e2ecc982fab683484a1a8561 # v1.0.1
         with:
           patterns: |
             downloads/*.dmg
@@ -46,7 +46,7 @@ jobs:
         run: echo ${{ steps.get_checksum.outputs.checksum }}
 
       - name: Extract Checksum From Checksum File Content
-        uses: tmelliottjr/extract-regex-action@v1.5.0
+        uses: tmelliottjr/extract-regex-action@2b16463481549ebe7270584fe9e65631a0235bfd # v1.5.0
         id: extract_checksum
         with:
           regex: '^\w+'
@@ -54,7 +54,7 @@ jobs:
           input: ${{ steps.get_checksum.outputs.checksum }}
 
       - name: Find and Replace sha256 In Cask File
-        uses: jacobtomlinson/gha-find-replace@v3
+        uses: jacobtomlinson/gha-find-replace@2ff30f644d2e0078fc028beb9193f5ff0dcad39e # v3
         with:
           include: "Casks/pikachuexe-freetube.rb"
           find: 'sha256 "\w+"'
@@ -62,7 +62,7 @@ jobs:
           regex: true
 
       - name: Extract Version From Release
-        uses: tmelliottjr/extract-regex-action@v1.5.0
+        uses: tmelliottjr/extract-regex-action@2b16463481549ebe7270584fe9e65631a0235bfd # v1.5.0
         id: extract_version
         with:
           regex: '\d+(\.\d+)+'
@@ -70,7 +70,7 @@ jobs:
           input: ${{ steps.download_files.outputs.tag_name }}
 
       - name: Find and Replace version In Cask File
-        uses: jacobtomlinson/gha-find-replace@v3
+        uses: jacobtomlinson/gha-find-replace@2ff30f644d2e0078fc028beb9193f5ff0dcad39e # v3
         with:
           include: "Casks/pikachuexe-freetube.rb"
           find: 'version "\d+(\.\d+)+"'
@@ -79,7 +79,7 @@ jobs:
 
       - name: Get Token
         id: get_workflow_token
-        uses: peter-murray/workflow-application-token-action@v4
+        uses: peter-murray/workflow-application-token-action@8e4e6fbf6fcc8a272781d97597969d21b3812974 # v4.0.0
         with:
           application_id: ${{ secrets.APPLICATION_ID }}
           application_private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Create Pull Request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@67ccf781d68cd99b580ae25a5c18a1cc84ffff1f # v7.0.6
         with:
           token: "${{ steps.get_workflow_token.outputs.token }}"
           commit-message: '[create-pull-request] Update Cask'


### PR DESCRIPTION
Per GitHub's [security guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions "https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions"):
> - Pin actions to a full length commit SHA
>
>   Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

This should be a non-breaking change, as Dependabot [updates comments in GitHub Actions workflows referencing action versions](https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/ "https://github.blog/changelog/2022-10-31-dependabot-now-updates-comments-in-github-actions-workflows-referencing-action-versions/"):
> GitHub Actions workflows often specify the version of an action using the commit SHA. Since commit SHAs are immutable, this ensures that Actions always picks the same version. Commit SHAs, however, are not very human friendly, so best practice is to include the semver version in a comment next to the SHA. Dependabot will now update the semver version in comments when updating Actions workflows with a commit SHA version.

Generated via [`pinact run`](https://formulae.brew.sh/formula/pinact#default "https://formulae.brew.sh/formula/pinact#default").