### PR TITLE
ci: sync actionlint workflow from upstream

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,7 +1,0 @@
-self-hosted-runner:
-  # Labels of self-hosted runner in array of strings.
-  labels: []
-# Configuration variables in array of strings defined in your repository or
-# organization. `null` means disabling configuration variables check.
-# Empty array means no configuration variable is allowed.
-config-variables: []

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,53 +1,56 @@
+# This file is synced from the `Homebrew/.github` repository, and
+# modified for this `PikachuEXE/homebrew-FreeTube` repository.
+
 name: actionlint
+
 on:
   push:
     branches:
       - master
     paths:
       - '.github/workflows/*.ya?ml'
-      - '.github/actionlint.yaml'
   pull_request:
     paths:
       - '.github/workflows/*.ya?ml'
-      - '.github/actionlint.yaml'
+
+defaults:
+  run:
+    shell: bash -xeuo pipefail {0}
+
 concurrency:
   group: "actionlint-${{ github.ref }}"
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_ENV_HINTS: 1
+
+permissions: {}
+
 jobs:
   workflow_syntax:
     if: github.repository_owner == 'PikachuEXE'
     runs-on: ubuntu-latest
-    container:
-      # https://github.com/Homebrew/brew/pkgs/container/ubuntu24.04
-      image: ghcr.io/homebrew/ubuntu24.04:latest
+    permissions:
+      contents: read
     steps:
       - name: Set up Homebrew
         id: setup-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
-          core: true
+          core: false
           cask: false
           test-bot: false
+
+      - name: Install tools
+        run: brew install actionlint shellcheck
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Set up actionlint
-        shell: bash
-        env:
-          HOMEBREW_TAP_REPOSITORY: ${{ steps.setup-homebrew.outputs.repository-path }}
-        run: |
-          brew install actionlint shellcheck
+        run: echo "::add-matcher::$(brew --repository)/.github/actionlint-matcher.json"
 
-          # Annotations work only relative to GITHUB_WORKSPACE
-          (shopt -s dotglob; rm -rf "${GITHUB_WORKSPACE:?}"/*; mv "${HOMEBREW_TAP_REPOSITORY:?}"/* "$GITHUB_WORKSPACE")
-          rmdir "$HOMEBREW_TAP_REPOSITORY"
-          ln -vs "$GITHUB_WORKSPACE" "$HOMEBREW_TAP_REPOSITORY"
-
-          # Setting `shell: /bin/bash` prevents shellcheck from running on
-          # those steps, so let's change them to `shell: bash` for linting.
-          sed -i 's:/bin/bash -e {0}:bash:' .github/workflows/*.y*ml
-          # The JSON matcher needs to be accessible to the container host.
-          cp "$(brew --repository)/.github/actionlint-matcher.json" "$HOME"
-          echo "::add-matcher::$HOME/actionlint-matcher.json"
       - run: actionlint


### PR DESCRIPTION
https://github.com/Homebrew/.github/blob/master/.github/workflows/actionlint.yml

Homebrew moved the actionlint workflow it shares across its many repos to Homebrew/.github on 31 October 2024. The actionlint workflow has changed quite a bit and now does not use a docker image.

---

As a side note, on merge of https://github.com/PikachuEXE/homebrew-FreeTube/pull/55 the `brew install` step of the actionlint workflow succeeded... Go figure.